### PR TITLE
修复了几处bug，使“root: /”设置为“root: /XXXXXX/”能正常显示

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,10 @@ Copyright © Art Chen
 Please do not remove the "Theme by Art Chen" text and links.
 
 请不要删除页面底部的作者信息和链接。
+
+
+# 更改||修正  （2018.03.06）
+
+1. 修复了几处bug。在全局`_config.yml`中，若需设置`root: /`为`root: /XXXXXX/`，现在可以正常显示了（`_sidebar.less`中背景图片的路径暂不清楚如何修正，需手动更改一下即可）。
+2. 已修正让`html`标签包裹`body`标签。
+3. 注释掉了`scripts.ejs`中的`Swiftype`，因其配置与作者网站(ttps://artifact.me)绑定了。

--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ Please do not remove the "Theme by Art Chen" text and links.
 请不要删除页面底部的作者信息和链接。
 
 
-# 更改||修正  （2018.03.06）
+## 更改||修正  （2018.03.06）
 
-1. 修复了几处bug。在全局`_config.yml`中，若需设置`root: /`为`root: /XXXXXX/`，现在可以正常显示了（`_sidebar.less`中背景图片的路径暂不清楚如何修正，需手动更改一下即可）。
-2. 已修正让`html`标签包裹`body`标签。
-3. 注释掉了`scripts.ejs`中的`Swiftype`，因其配置与作者网站(ttps://artifact.me)绑定了。
+* 修复了几处bug。在全局`_config.yml`中，若需设置`root: /`为`root: /XXXXXX/`，现在可以正常显示了（`_sidebar.less`中背景图片的路径暂不清楚如何修正，需手动更改一下即可）。
+* 已修正让`html`标签包裹`body`标签。
+* 注释掉了`scripts.ejs`中的`Swiftype`，因其配置与作者网站(ttps://artifact.me)绑定了。
+
+## 注意
+> 要给文章显示目录索引，需在文章头部添加`toc: true`。

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-<html>
 <head>
   <meta charset="utf-8">
   <%
@@ -20,10 +18,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <%- open_graph({twitter_id: theme.twitter, google_plus: theme.google_plus, fb_admins: theme.fb_admins, fb_app_id: theme.fb_app_id}) %>
   <% if (theme.rss) { %>
-    <link rel="alternative" href="<%- theme.rss %>" title="<%= config.title %>" type="application/atom+xml">
+    <link rel="alternative" href="<%- url_for(theme.rss) %>" title="<%= config.title %>" type="application/atom+xml">
   <% } %>
   <% if (theme.favicon) { %>
-    <link rel="icon" href="<%- theme.favicon %>">
+    <link rel="icon" href="<%- url_for(theme.favicon) %>">
   <% } %>
   
 	<!-- If needed, replace your own web font service -->

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -2,7 +2,7 @@
 
 <header id="header" class="site-header clearfix">
 
-  <a class="logo square clearfix" href="/">
+  <a class="logo square clearfix" href="<%- url_for()%>">
     <!-- 
       Replace with your own size name, for example:
       <span class="b">A</span>

--- a/layout/_partial/scripts.ejs
+++ b/layout/_partial/scripts.ejs
@@ -38,8 +38,8 @@
 <% } %>
 
 <!-- Swiftype -->
-
-<script type="text/javascript">
+<!-- Swiftype的此配置与作者网站（https://artifact.me/）绑定了。如果你想用在自己的网站，需更改其中的一些配置 -->
+<!-- <script type="text/javascript">
   /* Swiftype */
   (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
   (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
@@ -47,7 +47,7 @@
   })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
 
   _st('install','FHMeAyBdVccJECstf-XJ','2.0.0');
-</script>
+</script> -->
 
 <!-- Go to www.addthis.com/dashboard to customize your tools -->
 <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-569722b77263e377" async="async"></script>

--- a/layout/_partial/sidebar.ejs
+++ b/layout/_partial/sidebar.ejs
@@ -29,10 +29,10 @@
 	  <!-- About Me -->
 	  <div class="about-me clearfix">
 	    <div class="avatar">
-	      <img src="<%- theme.author_avatar %>" />
+	      <img src="<%- url_for(theme.author_avatar) %>" />
 	    </div>
 	    <div class="info">
-	      <a class="name dark-btn" href="/about">
+	      <a class="name dark-btn" href="<%- url_for() %>about">
 	        <%- config.author %>
 	      </a>
 	    </div>
@@ -48,7 +48,7 @@
 	    <% if (theme.social) { %>
 	      <% theme.social.forEach(function(value, key) {
 	           if (value.url && value.name) { %>
-	        <a href="<%= value.url %>" class="<%= value.name %>"
+	        <a href="<%= url_for(value.url) %>" class="<%= value.name %>"
 	          target="_blank" rel="external">
 	          <span class="icon icon-<%= value.name %>"></span>
 	        </a>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+<html>
 <%- partial('_partial/head') %>
 <body>
   <div class="site-wrapper">


### PR DESCRIPTION
- 1. 修复了几处bug。在全局`_config.yml`中，若需设置`root: /`为`root: /XXXXXX/`，现在可以正常显示了（`_sidebar.less`中背景图片的路径暂不清楚如何修正，需手动更改一下即可）。

- 2. 已修正让`html`标签包裹`body`标签。